### PR TITLE
Adding scheduling delay of 0.1msec (100micro second) per packet.

### DIFF
--- a/cp/cp_io_poll.c
+++ b/cp/cp_io_poll.c
@@ -49,9 +49,8 @@ incoming_event_handler(void* data)
             LOG_MSG(LOG_DEBUG,"handle stack unwind event %s ",event_names[event->event]);
             event->cb(event->data, event->event);
             free(event);
-            continue;
         }
-        usleep(10);
+        usleep(100); // every pkt 0.1 ms default scheduling delay
     }
     LOG_MSG(LOG_ERROR,"exiting event handler thread %p", data);
     return NULL;

--- a/cp/cp_test.c
+++ b/cp/cp_test.c
@@ -36,9 +36,8 @@ test_event_thread(void* data)
             LOG_MSG(LOG_INFO,"handle stack unwind event %s ",event_names[event->event]);
             event->cb(event->data, event->event);
             free(event);
-            continue;
         }
-        usleep(10);
+        usleep(100); // every pkt 0.1 ms default scheduling delay
     }
     LOG_MSG(LOG_ERROR, "exiting event handler thread %p", data);
     return NULL;

--- a/cp/gtpv2/common/gtpv2_interface.c
+++ b/cp/gtpv2/common/gtpv2_interface.c
@@ -242,10 +242,8 @@ out_handler_gtp(void *data)
 			}
             free(event->payload);
             free(event);
-            continue;
         }
-        //PERFORAMANCE ISSUE - use conditional variable 
-        usleep(10);
+        usleep(100); // every pkt 0.1 ms default scheduling delay 
     }
 	LOG_MSG(LOG_ERROR,"Exiting gtp out message handler thread %p", data);
     return NULL;

--- a/cp/gx/gx_interface.c
+++ b/cp/gx/gx_interface.c
@@ -700,10 +700,9 @@ out_handler_gx(void *data)
             send_to_ipc_channel(event->fd, (char *)event->payload, event->payload_len);
             free(event->payload);
             free(event);
-            continue;
         }
         //PERFORAMANCE ISSUE - use conditional variable 
-        usleep(10);
+        usleep(100); // every pkt 0.1 ms default scheduling delay
     }
 	LOG_MSG(LOG_ERROR,"gx out message handler thread exited , data %p ", data);
     return NULL;

--- a/cp/pfcp/common/pfcp_interface.c
+++ b/cp/pfcp/common/pfcp_interface.c
@@ -104,10 +104,9 @@ out_handler_pfcp(void *data)
             }
             free(event->payload);
             free(event);
-            continue;
         }
         //PERFORAMANCE ISSUE - use conditional variable 
-        usleep(10);
+        usleep(100); // every pkt 0.1 ms default scheduling delay 
     }
 	LOG_MSG(LOG_INIT,"Exiting : pfcp out message handler thread data = %p ", data);
     return NULL;


### PR DESCRIPTION
This will avoid burst of packets towards UPF. Sometimes this
causes packet loss. We might have to come back to this code
later to better handle peer capabilities.