### PR TITLE
Allocate UE IP address in control plane only if UPF does not

### DIFF
--- a/cp/cp_main.c
+++ b/cp/cp_main.c
@@ -173,31 +173,9 @@ main(int argc, char **argv)
     init_fqcsid_hash_tables();
 #endif /* USE_CSID */
 
-	if (signal(SIGINT, sig_handler) == SIG_ERR)
-        assert(0);
-
-	if (signal(SIGSEGV, sig_handler) == SIG_ERR)
-        assert(0);
-
     while(1) {
 		incoming_event_handler(NULL);
     }
 
     return 0;
 }
-
-void sig_handler(int signo)
-{
-    if (signo == SIGINT) {
-        if (my_sock.gx_app_sock > 0)
-            close_ipc_channel(my_sock.gx_app_sock);
-
-        gst_deinit();
-
-        assert(0);
-    }
-    else if (signo == SIGSEGV)
-        assert(0);
-}
-
-

--- a/cp/cp_main.h
+++ b/cp/cp_main.h
@@ -24,15 +24,6 @@ extern uint16_t local_csid;
 extern int32_t conn_cnt;
 
 
-/**
- * @brief  : Functino to handle signals.
- * @param  : signo
- *           signal number signal to be handled
- * @return : Returns nothing
- */
-void sig_handler(int signo);
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/cp/pdn.h
+++ b/cp/pdn.h
@@ -106,6 +106,7 @@ while(0);
 
 #define IF_PDN_ADDR_STATIC(pdn)   ((pdn->pdn_flags & PDN_STATIC_ADDR) == PDN_STATIC_ADDR)
 #define SET_PDN_ADDR_METHOD(pdn, flag) (pdn->pdn_flags = pdn->pdn_flags | flag)
+#define RESET_PDN_ADDR_METHOD(pdn, flag) (pdn->pdn_flags = pdn->pdn_flags & (~flag))
 #define IF_PDN_ADDR_ALLOC_CONTROL(pdn) (pdn->pdn_flags & PDN_ADDR_ALLOC_CONTROL)
 #define IF_PDN_ADDR_ALLOC_UPF(pdn) (pdn->pdn_flags & PDN_ADDR_ALLOC_UPF)
 

--- a/cpplib/spgw_config.cpp
+++ b/cpplib/spgw_config.cpp
@@ -169,7 +169,7 @@ spgwConfig::parse_json_doc(rapidjson::Document &doc)
                         }
                         --ptr;
                     } while (ptr != key->apn.requested_apn);
-                    LOG_MSG(LOG_INIT,"\t\tAPN name after encode [%s] and length %d ",key->apn.requested_apn, strlen(key->apn.requested_apn));
+                    LOG_MSG(LOG_INIT,"\t\tAPN name after encode [%s] and length %lu ",key->apn.requested_apn, strlen(key->apn.requested_apn));
 
                 }
             }


### PR DESCRIPTION
Allocate UE IP address in control plane only if UPF does not support the address allocation feature.