### PR TITLE
PCRF crash due to  multiple back to back messages

### DIFF
--- a/cp/gtpv2/common/gtpv2_error_rsp.c
+++ b/cp/gtpv2/common/gtpv2_error_rsp.c
@@ -172,6 +172,7 @@ void cs_error_response(msg_info_t *msg, uint8_t cause_value, int iface)
 
     assert(msg->peer_addr.sin_port != 0);
 
+#ifdef SEND_CCRT_CONTEXT_RELEASE
     // Sending CCR-T in case of failure
     /* we should check if subscriber has gx session..this does not look good */
     if ((cp_config->gx_enabled) &&  
@@ -183,6 +184,7 @@ void cs_error_response(msg_info_t *msg, uint8_t cause_value, int iface)
         inet_aton("127.0.0.1", &(saddr_in.sin_addr));
         increment_gx_peer_stats(MSG_TX_DIAMETER_GX_CCR_T,saddr_in.sin_addr.s_addr);
     }
+#endif
     bzero(&gtp_tx_buf, sizeof(gtp_tx_buf));
 
     gtpv2c_header_t *gtpv2c_tx = (gtpv2c_header_t *) gtp_tx_buf;
@@ -451,7 +453,7 @@ ds_error_response(proc_context_t *ds_proc, msg_info_t *msg, uint8_t cause_value,
 
     assert(msg->peer_addr.sin_port != 0);
 
-#ifdef FUTURE_NEED
+#ifdef SEND_CCRT_CONTEXT_RELEASE
     // FIXME : why we need to send CCRT while sending DSRsp ?
 	uint8_t eps_bearer_id = 0;
     /* we should check if subscriber has gx session..this does not look good */

--- a/cp/sm_error_handlers.c
+++ b/cp/sm_error_handlers.c
@@ -133,8 +133,6 @@ process_error_occured_handler_new(void *data, void *unused_param)
 
     do {
 	    if ((cp_config->gx_enabled)) {
-	        gx_msg ccr_request = {0};
-            uint16_t msglen;
 
 	    	/* Retrive Gx_context based on Sess ID. */
 	    	ue_context_t *temp_context  = (ue_context_t *)get_ue_context_from_gxsessid((uint8_t *)pdn->gx_sess_id); 
@@ -143,6 +141,10 @@ process_error_occured_handler_new(void *data, void *unused_param)
                 break;
 	    	}
             assert(temp_context == context);
+
+#ifdef SEND_CCRT_CONTEXT_RELEASE
+            gx_msg ccr_request = {0};
+            uint16_t msglen;
 
 	    	/* VS: Set the Msg header type for CCR-T */
 	    	ccr_request.msg_type = GX_CCR_MSG ;
@@ -185,6 +187,7 @@ process_error_occured_handler_new(void *data, void *unused_param)
             saddr_in.sin_family = AF_INET;
             inet_aton("127.0.0.1", &(saddr_in.sin_addr));
             increment_gx_peer_stats(MSG_TX_DIAMETER_GX_CCR_T, saddr_in.sin_addr.s_addr);
+#endif
 			if(remove_gxsessid_to_context((uint8_t*)pdn->gx_sess_id) < 0){
  	            LOG_MSG(LOG_ERROR, " Error on remove_gx_context for session Id %s",pdn->gx_sess_id);
 			}


### PR DESCRIPTION
sgw sends delete followed by add during context replacement,
that causes issues at pcrf. For now disabling the delete message
during context replacement & error. This also means that PCRF
needs to handle context replacement.